### PR TITLE
CMake Tools Fix

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+    "recommendations": [
+        "ms-vscode.cpptools",
+        "ms-vscode.cmake-tools"
+    ]
+}

--- a/utils/cmake/toolchains/ARM_GCC/toolchain.cmake
+++ b/utils/cmake/toolchains/ARM_GCC/toolchain.cmake
@@ -16,9 +16,9 @@ if(CMAKE_VERSION VERSION_LESS "3.5.0")
 else()
     # from 3.5 the force_compiler macro is deprecated: CMake can detect
     # arm-none-eabi-gcc as being a GNU compiler automatically
-	set(CMAKE_TRY_COMPILE_TARGET_TYPE "STATIC_LIBRARY")
-    set(CMAKE_C_COMPILER "${ARM_NONE_EABI_GCC}")
-    set(CMAKE_CXX_COMPILER "${ARM_NONE_EABI_GPP}")
+    set(CMAKE_TRY_COMPILE_TARGET_TYPE "STATIC_LIBRARY")
+    #set(CMAKE_C_COMPILER "${ARM_NONE_EABI_GCC}")
+    #set(CMAKE_CXX_COMPILER "${ARM_NONE_EABI_GPP}")
 endif()
 
 SET(CMAKE_AR "${ARM_NONE_EABI_AR}" CACHE FILEPATH "Archiver")

--- a/utils/cmake/toolchains/ARM_GCC/toolchain.cmake
+++ b/utils/cmake/toolchains/ARM_GCC/toolchain.cmake
@@ -17,8 +17,13 @@ else()
     # from 3.5 the force_compiler macro is deprecated: CMake can detect
     # arm-none-eabi-gcc as being a GNU compiler automatically
     set(CMAKE_TRY_COMPILE_TARGET_TYPE "STATIC_LIBRARY")
-    #set(CMAKE_C_COMPILER "${ARM_NONE_EABI_GCC}")
-    #set(CMAKE_CXX_COMPILER "${ARM_NONE_EABI_GPP}")
+
+    # only include if running from build.py
+    if(MANUAL_COMPILER_INCLUDE)
+        message("Manually including compiler paths.")
+        set(CMAKE_C_COMPILER "${ARM_NONE_EABI_GCC}")
+        set(CMAKE_CXX_COMPILER "${ARM_NONE_EABI_GPP}")
+    endif()
 endif()
 
 SET(CMAKE_AR "${ARM_NONE_EABI_AR}" CACHE FILEPATH "Archiver")

--- a/utils/python/codal_utils.py
+++ b/utils/python/codal_utils.py
@@ -16,7 +16,7 @@ def system(cmd):
 
 def build(clean, verbose = False):
     # configure
-    system("cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -G \"Ninja\"")
+    system("cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -DMANUAL_COMPILER_INCLUDE=true -G \"Ninja\"")
 
     # build
     system("ninja")

--- a/utils/python/codal_utils.py
+++ b/utils/python/codal_utils.py
@@ -15,24 +15,11 @@ def system(cmd):
       sys.exit(1)
 
 def build(clean, verbose = False):
-    if platform.system() == "Windows":
-        # configure
-        system("cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -G \"Ninja\"")
+    # configure
+    system("cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -G \"Ninja\"")
 
-        # build
-        system("ninja")
-    else:
-        # configure
-        system("cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -G \"Unix Makefiles\"")
-
-        if clean:
-            system("make clean")
-
-        # build
-        if verbose:
-            system("make -j 10 VERBOSE=1")
-        else:
-            system("make -j 10")
+    # build
+    system("ninja")
 
 def read_json(fn):
     json_file = ""


### PR DESCRIPTION
This allows for automatic CMake configuration in the VSCode CMake Build Tools.
It also allows for Intellisense to correctly navigate the repository (submodules included).

Now when opening the project for the first time the extension:

1. Asks the user which compiler they'd like to use from the list of detected ones (if not detected, the user can explicitly say where they are in cmake-lists.json - maybe a template could be supplied?)
2. Configures the whole project through CMake.

It also uses Ninja on both Windows and Unix platforms, rather than Make on Unix and Ninja on Windows, since they are cross-platform and Ninja is faster on both.

This can be used interchangably with build.py through a new `MANUAL_COMPILER_INCLUDE` flag that build.py now passes to CMake (which the extension won't).